### PR TITLE
[feature] Web server can echo back

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -1,0 +1,7 @@
+package main
+
+const (
+	// TODO: parameterize with env variables
+	serverPort = "8080"
+	address    = "localhost:" + serverPort
+)

--- a/server/main.go
+++ b/server/main.go
@@ -11,12 +11,6 @@ import (
 	"time"
 )
 
-const (
-	// TODO: parameterize with env variables
-	serverPort = "8080"
-	address    = "localhost:" + serverPort
-)
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()


### PR DESCRIPTION
This pull request addresses first point of #4.

You can test it by running the server and doing some queries against it. e.g., on one terminal
```
go run ./server/
```

And on the other:
```bash
curl -d "foo" localhost:8080/echo
```

Expect an echo back.