### PR TITLE
[maintenance] Only run server pipeline when necessary

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -7,8 +7,6 @@ import (
 	"syscall"
 )
 
-// trigger build demo
-
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()


### PR DESCRIPTION
- make sure that it is only triggered on go file changes (example commit where it ran https://github.com/luisferreira32/stickian/actions/runs/21964743609/job/63451484962)
- do not run after pushed on main