### PR TITLE
Create JoinWorld endpoint

### DIFF
--- a/server/internal/game/city.go
+++ b/server/internal/game/city.go
@@ -95,22 +95,22 @@ func (g *GameService) GetCities(w http.ResponseWriter, r *http.Request) {
 
 	q1, err := parseIntParam("q1")
 	if err != nil {
-		utils.WithError(w, fmt.Errorf("invalid q1 parameter: %w", err))
+		utils.WithError(w, fmt.Errorf("%w: invalid q1 parameter: %w", utils.ErrUserError, err))
 		return
 	}
 	r1, err := parseIntParam("r1")
 	if err != nil {
-		utils.WithError(w, fmt.Errorf("invalid r1 parameter: %w", err))
+		utils.WithError(w, fmt.Errorf("%w: invalid r1 parameter: %w", utils.ErrUserError, err))
 		return
 	}
 	q2, err := parseIntParam("q2")
 	if err != nil {
-		utils.WithError(w, fmt.Errorf("invalid q2 parameter: %w", err))
+		utils.WithError(w, fmt.Errorf("%w: invalid q2 parameter: %w", utils.ErrUserError, err))
 		return
 	}
 	r2, err := parseIntParam("r2")
 	if err != nil {
-		utils.WithError(w, fmt.Errorf("invalid r2 parameter: %w", err))
+		utils.WithError(w, fmt.Errorf("%w: invalid r2 parameter: %w", utils.ErrUserError, err))
 		return
 	}
 

--- a/server/internal/game/city_test.go
+++ b/server/internal/game/city_test.go
@@ -148,8 +148,8 @@ func Test_GetCities(t *testing.T) {
 		{
 			name:       "missing parameter",
 			query:      "q1=0&r1=0&q2=10",
-			wantStatus: 500,
-			wantBody:   []byte("invalid r2 parameter: missing required parameter: r2\n"),
+			wantStatus: 400,
+			wantBody:   []byte("user error: invalid r2 parameter: missing required parameter: r2\n"),
 		},
 		{
 			name:       "database error",

--- a/server/internal/game/city_test.go
+++ b/server/internal/game/city_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type mockDatabase struct {
-	GetCityFunc   func(id string, userID string) (*City, error)
-	GetCitiesFunc func(q1, r1, q2, r2 int) ([]*City, error)
-	GetMapFunc    func(minQ, maxQ, minR, maxR int) ([]*MapTile, error)
+	GetCityFunc    func(id string, userID string) (*City, error)
+	GetCitiesFunc  func(q1, r1, q2, r2 int) ([]*City, error)
+	CreateCityFunc func(c *City) error
+	GetMapFunc     func(minQ, maxQ, minR, maxR int) ([]*MapTile, error)
 }
 
 func (db *mockDatabase) GetCity(_ context.Context, id string, userID string) (*City, error) {
@@ -24,6 +25,10 @@ func (db *mockDatabase) GetCity(_ context.Context, id string, userID string) (*C
 
 func (db *mockDatabase) GetCities(_ context.Context, q1, r1, q2, r2 int) ([]*City, error) {
 	return db.GetCitiesFunc(q1, r1, q2, r2)
+}
+
+func (db *mockDatabase) CreateCity(_ context.Context, c *City) error {
+	return db.CreateCityFunc(c)
 }
 
 func (db *mockDatabase) GetMap(_ context.Context, minQ, maxQ, minR, maxR int) ([]*MapTile, error) {

--- a/server/internal/game/database.go
+++ b/server/internal/game/database.go
@@ -5,10 +5,7 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
-)
-
-var (
-	ErrNotFound = errors.New("not found")
+	"github.com/luisferreira32/stickian/server/internal/utils"
 )
 
 type MapTile struct {
@@ -56,7 +53,7 @@ func (db *PostgresDatabase) GetCity(ctx context.Context, id string, userID strin
 		&city.Buildings.Workshop, &city.Buildings.Observatory, &city.Buildings.Temple, &city.Buildings.Shrine, &city.Buildings.Cathedral,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, ErrNotFound
+		return nil, utils.ErrNotFound
 	}
 	if err != nil {
 		return nil, err

--- a/server/internal/game/database.go
+++ b/server/internal/game/database.go
@@ -3,6 +3,7 @@ package game
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/luisferreira32/stickian/server/internal/utils"
@@ -17,6 +18,7 @@ type MapTile struct {
 type GameDatabase interface {
 	GetCity(ctx context.Context, id string, userID string) (*City, error)
 	GetCities(ctx context.Context, q1, r1, q2, r2 int) ([]*City, error)
+	CreateCity(ctx context.Context, c *City) error
 	GetMap(ctx context.Context, minQ, maxQ, minR, maxR int) ([]*MapTile, error)
 }
 
@@ -43,14 +45,40 @@ func (db *PostgresDatabase) GetCity(ctx context.Context, id string, userID strin
 		Buildings: &Buildings{},
 	}
 	err := db.DB.QueryRow(ctx, getCityQuery, id, userID).Scan(
-		&city.ID, &city.PlayerID, &city.Name, &city.Q, &city.R, &city.Biome, &city.Points,
-		&city.Resources.Food, &city.Resources.Sticks, &city.Resources.Stones,
-		&city.Resources.Gems, &city.Resources.Population, &city.Resources.Faith,
-		&city.Buildings.CityHall, &city.Buildings.Embassy, &city.Buildings.Treasury, &city.Buildings.Tavern,
-		&city.Buildings.Farm, &city.Buildings.Lumbermill, &city.Buildings.Quarry, &city.Buildings.CrystalMine,
-		&city.Buildings.Warehouse, &city.Buildings.Market, &city.Buildings.Harbor, &city.Buildings.Walls,
-		&city.Buildings.Barracks, &city.Buildings.Docks, &city.Buildings.SpyGuild, &city.Buildings.Library,
-		&city.Buildings.Workshop, &city.Buildings.Observatory, &city.Buildings.Temple, &city.Buildings.Shrine, &city.Buildings.Cathedral,
+		&city.ID,
+		&city.PlayerID,
+		&city.Name,
+		&city.Q,
+		&city.R,
+		&city.Biome,
+		&city.Points,
+		&city.Resources.Food,
+		&city.Resources.Sticks,
+		&city.Resources.Stones,
+		&city.Resources.Gems,
+		&city.Resources.Population,
+		&city.Resources.Faith,
+		&city.Buildings.CityHall,
+		&city.Buildings.Embassy,
+		&city.Buildings.Treasury,
+		&city.Buildings.Tavern,
+		&city.Buildings.Farm,
+		&city.Buildings.Lumbermill,
+		&city.Buildings.Quarry,
+		&city.Buildings.CrystalMine,
+		&city.Buildings.Warehouse,
+		&city.Buildings.Market,
+		&city.Buildings.Harbor,
+		&city.Buildings.Walls,
+		&city.Buildings.Barracks,
+		&city.Buildings.Docks,
+		&city.Buildings.SpyGuild,
+		&city.Buildings.Library,
+		&city.Buildings.Workshop,
+		&city.Buildings.Observatory,
+		&city.Buildings.Temple,
+		&city.Buildings.Shrine,
+		&city.Buildings.Cathedral,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, utils.ErrNotFound
@@ -93,6 +121,74 @@ func (db *PostgresDatabase) GetCities(ctx context.Context, q1, r1, q2, r2 int) (
 		cities = append(cities, city)
 	}
 	return cities, nil
+}
+
+const createCityQuery = `INSERT INTO city (id, player_id, name, q, r, biome, points)
+	VALUES ($1, $2, $3, $4, $5, $6, $7)
+	ON CONFLICT DO NOTHING`
+
+const createCityResourcesQuery = `INSERT INTO city_resources (city_id, food, sticks, stones, gems, population, faith)
+	VALUES ($1, $2, $3, $4, $5, $6, $7)
+	ON CONFLICT DO NOTHING`
+
+const createCityBuildingsQuery = `INSERT INTO city_buildings (city_id, city_hall, embassy, treasury, tavern, farm, lumbermill, quarry, crystal_mine, warehouse, market, harbor, walls, barracks, docks, spy_guild, library, workshop, observatory, temple, shrine, cathedral)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+	ON CONFLICT DO NOTHING`
+
+func (db *PostgresDatabase) CreateCity(ctx context.Context, c *City) error {
+	_, err := db.DB.Exec(ctx, createCityQuery,
+		c.ID,
+		c.PlayerID,
+		c.Name,
+		c.Q,
+		c.R,
+		c.Biome,
+		c.Points,
+	)
+	if err != nil {
+		return fmt.Errorf("city creation: %w", err)
+	}
+	_, err = db.DB.Exec(ctx, createCityResourcesQuery,
+		c.ID,
+		c.Resources.Food,
+		c.Resources.Sticks,
+		c.Resources.Stones,
+		c.Resources.Gems,
+		c.Resources.Population,
+		c.Resources.Faith,
+	)
+	if err != nil {
+		return fmt.Errorf("city resources: %w", err)
+	}
+	_, err = db.DB.Exec(ctx, createCityBuildingsQuery,
+		c.ID,
+		c.Buildings.CityHall,
+		c.Buildings.Embassy,
+		c.Buildings.Treasury,
+		c.Buildings.Tavern,
+		c.Buildings.Farm,
+		c.Buildings.Lumbermill,
+		c.Buildings.Quarry,
+		c.Buildings.CrystalMine,
+		c.Buildings.Warehouse,
+		c.Buildings.Market,
+		c.Buildings.Harbor,
+		c.Buildings.Walls,
+		c.Buildings.Barracks,
+		c.Buildings.Docks,
+		c.Buildings.SpyGuild,
+		c.Buildings.Library,
+		c.Buildings.Workshop,
+		c.Buildings.Observatory,
+		c.Buildings.Temple,
+		c.Buildings.Shrine,
+		c.Buildings.Cathedral,
+	)
+	if err != nil {
+		return fmt.Errorf("city buildings: %w", err)
+	}
+
+	return nil
 }
 
 const getMapQuery = "SELECT q, r, biome FROM world WHERE q BETWEEN $1 AND $2 AND r BETWEEN $3 AND $4"

--- a/server/internal/game/game.go
+++ b/server/internal/game/game.go
@@ -1,5 +1,106 @@
 package game
 
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/luisferreira32/stickian/server/internal/utils"
+)
+
+var (
+	// InitialResources for a new city
+	//
+	// The objective of these initial resources is that it is enough for the creation
+	// of the resource producing buildings to a certain extent
+	//
+	// TODO: change these resources to match building costs once we define a cost table for building upgrades
+	InitialResources = &Resources{
+		Food:       100,
+		Sticks:     100,
+		Stones:     100,
+		Gems:       0,
+		Population: 10,
+		Faith:      0,
+	}
+)
+
 type GameService struct {
 	Database GameDatabase
+}
+
+type JoinWorldRequest struct {
+	CityName string `json:"cityName"`
+}
+
+type JoinWorldResponse struct {
+	CityID string `json:"cityID"`
+}
+
+func validJoinWorldRequest(req *JoinWorldRequest) string {
+	if req == nil {
+		return "must provide a valid request"
+	}
+	if req.CityName == "" {
+		return "city name is required"
+	}
+	return ""
+}
+
+// JoinWorld is the first endpoint called once a logged in player wants to start a game.
+//
+// The endpoint returns the city ID of the newly generated city, or, if the endpoint was called
+// multiple times (e.g., network issues), it returns the city ID of the first city created for
+// this player.
+//
+// The first city ID, which is a UUID, will be the player ID such that multiple calls to this endpoint
+// do NOT create multiple cities in the world, and instead always return the first created city.
+func (g *GameService) JoinWorld(w http.ResponseWriter, r *http.Request) {
+	bodyReader := http.MaxBytesReader(w, r.Body, utils.MaxRead)
+	defer func() {
+		_ = bodyReader.Close()
+	}()
+
+	req := JoinWorldRequest{}
+	if err := json.NewDecoder(bodyReader).Decode(&req); err != nil {
+		utils.WithError(w, fmt.Errorf("%w: invalid request body: %w", utils.ErrUserError, err))
+		return
+	}
+	if errReason := validJoinWorldRequest(&req); errReason != "" {
+		utils.WithError(w, fmt.Errorf("%w: %s", utils.ErrUserError, errReason))
+		return
+	}
+
+	userID, ok := r.Context().Value("sub").(string)
+	if !ok || userID == "" {
+		utils.WithError(w, utils.ErrUserUnauthorized)
+		return
+	}
+
+	// NOTE: The first city ID, which is a UUID, will be the player ID such that multiple calls to this endpoint
+	// do NOT create multiple cities in the world, and instead always return the first created city.
+	newCity := &City{
+		ID:        userID,
+		PlayerID:  userID,
+		Name:      req.CityName,
+		Q:         0,          // TODO: figure out once we know which spots of the map are buildable where the first city will land
+		R:         0,          // TODO: figure out once we know which spots of the map are buildable where the first city will land
+		Biome:     "mountain", // TODO: figure out once we know which spots of the map are buildable where the first city will land
+		Points:    0,
+		Buildings: &Buildings{},
+		Resources: InitialResources,
+	}
+
+	err := g.Database.CreateCity(r.Context(), newCity)
+	if err != nil {
+		utils.WithError(w, err)
+		return
+	}
+
+	rsp := JoinWorldResponse{CityID: userID}
+	utils.WithDefaultOKHeaders(w)
+	if err := json.NewEncoder(w).Encode(rsp); err != nil {
+		utils.WithError(w, fmt.Errorf("failed to encode response: %w", err))
+		return
+	}
 }

--- a/server/internal/game/game_test.go
+++ b/server/internal/game/game_test.go
@@ -1,0 +1,1 @@
+package game

--- a/server/internal/user/database.go
+++ b/server/internal/user/database.go
@@ -17,24 +17,6 @@ type UserDatabase interface {
 	GetUser(ctx context.Context, email string) (*User, error)
 }
 
-// InMemoryDatabase is a placeholder for an actual database implementation.
-type InMemoryDatabase struct {
-	UserTable map[string]*User
-}
-
-func (db *InMemoryDatabase) WriteUser(_ context.Context, u *User) error {
-	db.UserTable[u.Email] = u
-	return nil
-}
-
-func (db *InMemoryDatabase) GetUser(_ context.Context, email string) (*User, error) {
-	u, ok := db.UserTable[email]
-	if !ok {
-		return nil, errUserNotFound
-	}
-	return u, nil
-}
-
 type PostgresDatabase struct {
 	DB *pgx.Conn
 }

--- a/server/internal/user/user.go
+++ b/server/internal/user/user.go
@@ -10,10 +10,8 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
-)
 
-const (
-	maxRead = 1024 * 1024
+	"github.com/luisferreira32/stickian/server/internal/utils"
 )
 
 type UserService struct {
@@ -111,7 +109,7 @@ func validSignupRequest(req *SignupRequest, isDevelopment bool) string {
 }
 
 func (h *UserService) Signup(w http.ResponseWriter, r *http.Request) {
-	bodyReader := http.MaxBytesReader(w, r.Body, maxRead)
+	bodyReader := http.MaxBytesReader(w, r.Body, utils.MaxRead)
 	defer func() {
 		_ = bodyReader.Close()
 	}()
@@ -191,7 +189,7 @@ func validLoginRequest(req *LoginRequest) string {
 }
 
 func (h *UserService) Login(w http.ResponseWriter, r *http.Request) {
-	bodyReader := http.MaxBytesReader(w, r.Body, maxRead)
+	bodyReader := http.MaxBytesReader(w, r.Body, utils.MaxRead)
 	defer func() {
 		_ = bodyReader.Close()
 	}()

--- a/server/internal/utils/errors.go
+++ b/server/internal/utils/errors.go
@@ -14,4 +14,9 @@ var (
 	//
 	// If returned in the utils.WithError function, it will be translated to a 400 response.
 	ErrUserError = errors.New("user error")
+
+	// ErrUserUnauthorized can be used by the packages to indicate an error caused by lacking of permissions.
+	//
+	// If returned in the utils.WithError function, it will be translated to a 403 response.
+	ErrUserUnauthorized = errors.New("unauthorized")
 )

--- a/server/internal/utils/http.go
+++ b/server/internal/utils/http.go
@@ -5,6 +5,14 @@ import (
 	"net/http"
 )
 
+const (
+	// MaxRead is the default maximum ammount of bytes a write request may have
+	//
+	// Rule-of-thumb: use it to all POST/PUT/PATCH endpoints, and adjust down/up
+	// if necessary with a local variable.
+	MaxRead = 1024 * 1024
+)
+
 func WithDefaultOKHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
@@ -18,6 +26,8 @@ func WithError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	case errors.Is(err, ErrNotFound):
 		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, ErrUserUnauthorized):
+		http.Error(w, err.Error(), http.StatusUnauthorized)
 	default:
 		// TODO: do a better translation of internal errors to codes
 		// and do logging instead of returning to client - this way we

--- a/server/server.go
+++ b/server/server.go
@@ -71,6 +71,8 @@ func run(ctx context.Context, address, databaseURL, migrationsURL, secretKey str
 	mux.HandleFunc("POST /api/signup", chainMiddleware(userSvc.Signup, middlewares...))
 	// map endpoints
 	mux.HandleFunc("GET /api/map", chainMiddleware(gameSvc.GetMapChunk, middlewares...))
+	// game endpoints
+	mux.HandleFunc("POST /api/joinworld", chainMiddleware(gameSvc.JoinWorld, middlewares...))
 
 	// run the server
 	server := http.Server{Addr: address, Handler: mux}

--- a/tests/end2end/README.md
+++ b/tests/end2end/README.md
@@ -1,0 +1,5 @@
+# End to end tests
+
+This _really_ tests everything. Hotpath end-to-end, where the front-end, server and database are running and then we use an automated "agent" to interact with the front-end on the hotpath of our use flow.
+
+🛠️ 🛠️ 🛠️

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,5 @@
+# Integration tests
+
+Running full API integration tests: spin up a server with a database and run the whole flow.
+
+🛠️ 🛠️ 🛠️

--- a/tests/integration/hotpath_test.go
+++ b/tests/integration/hotpath_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+const (
+	testURL = "http://localhost:8080"
+)
+
+type SignupRequest struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type SignupResponse struct {
+	AccessToken string `json:"accessToken"`
+}
+
+type JoinWorldRequest struct {
+	CityName string `json:"cityName"`
+}
+
+type JoinWorldResponse struct {
+	CityID string `json:"cityID"`
+}
+
+func Test_Hotpath(t *testing.T) {
+	t.Log("Starting hotpath test: ensure server and database are running locally...")
+
+	// sign up
+	signupReq := &SignupRequest{
+		Username: "test user",
+		Email:    "test@example.com",
+		Password: "a-safe-pw",
+	}
+	signupReqBytes, err := json.Marshal(signupReq)
+	if err != nil {
+		t.Fatalf("failed to marshal signup req: %v", err)
+	}
+	signup, err := http.NewRequestWithContext(t.Context(), "POST", testURL+"/api/signup", bytes.NewReader(signupReqBytes))
+	if err != nil {
+		t.Fatalf("failed to create signup request: %v", err)
+	}
+	signupHTTPRsp, err := http.DefaultClient.Do(signup)
+	if err != nil {
+		t.Fatalf("failed to signup: %v", err)
+	}
+	signupRspBytes, err := io.ReadAll(signupHTTPRsp.Body)
+	if err != nil {
+		t.Fatalf("failed to read signup response: %v", err)
+	}
+	signupRsp := &SignupResponse{}
+	err = json.Unmarshal(signupRspBytes, signupRsp)
+	if err != nil {
+		t.Fatalf("failed to unmarshal signup response: %v, %s", err, signupRspBytes)
+	}
+
+	// join world
+	joinWorldReq := &JoinWorldRequest{
+		CityName: "a test city",
+	}
+	joinWorldReqBytes, err := json.Marshal(joinWorldReq)
+	if err != nil {
+		t.Fatalf("failed to marshal join world req: %v", err)
+	}
+	joinWorld, err := http.NewRequestWithContext(t.Context(), "POST", testURL+"/api/joinworld", bytes.NewReader(joinWorldReqBytes))
+	if err != nil {
+		t.Fatalf("failed to create signup request: %v", err)
+	}
+	joinWorld.Header.Add("Authorization", "Bearer "+signupRsp.AccessToken)
+
+	joinWorldHTTPRsp, err := http.DefaultClient.Do(joinWorld)
+	if err != nil {
+		t.Fatalf("failed to joinWorld: %v", err)
+	}
+	joinWorldRspBytes, err := io.ReadAll(joinWorldHTTPRsp.Body)
+	if err != nil {
+		t.Fatalf("failed to read joinWorld response: %v", err)
+	}
+	joinWorldRsp := &JoinWorldResponse{}
+	err = json.Unmarshal(joinWorldRspBytes, joinWorldRsp)
+	if err != nil {
+		t.Fatalf("failed to unmarshal joinWorld response: %v, %s", err, joinWorldRspBytes)
+	}
+
+	// get city
+	getCity, err := http.NewRequestWithContext(t.Context(), "GET", testURL+"/api/cities/"+joinWorldRsp.CityID, http.NoBody)
+	if err != nil {
+		t.Fatalf("failed to create getCity request: %v", err)
+	}
+	getCity.Header.Add("Authorization", "Bearer "+signupRsp.AccessToken)
+	getCityHTTPRsp, err := http.DefaultClient.Do(getCity)
+	if err != nil {
+		t.Fatalf("failed to getCity: %v", err)
+	}
+	getCityRspBytes, err := io.ReadAll(getCityHTTPRsp.Body)
+	if err != nil {
+		t.Fatalf("failed to read getCity response: %v", err)
+	}
+	t.Logf("got city:\n%s", getCityRspBytes)
+
+	t.Log("Successful hotpath test!")
+}

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,5 @@
+# Load tests
+
+Where we test the load in our servers!
+
+🛠️ 🛠️ 🛠️


### PR DESCRIPTION
This partially addresses #49 . There are some things still missing which I'd do in a follow-up PR.

- Once we complete #48, I can address the TODO of the endpoint to define a valid city position on joining the world
- In the future I can extend the backend github actions to run the hotpath as well
- Once we define the resource costs for upgrading city buildings we can re-define the initial resources on a city creation


---

In this PR, since we don't have the front-end to test, I added a hotpath testing where we can Signup, join the world, and see the city is there and returned! Unfortunately, at the moment, the test is a bit limited, and you have to manually clean-up the database locally if you want to run it again. 

Edit: If you want to run the test, you have to use go build tags, e.g.

```
cd tests/integration && go test -v -tags integration 
```