### PR TITLE
Return valid city location on join world

### DIFF
--- a/server/internal/game/city.go
+++ b/server/internal/game/city.go
@@ -19,7 +19,7 @@ type City struct {
 	Name      string     `json:"cityName"`
 	Q         int        `json:"q"`
 	R         int        `json:"r"`
-	Biome     string     `json:"biome"`
+	Biome     int        `json:"biome"`
 	Points    int        `json:"points"`
 	Buildings *Buildings `json:"buildings,omitempty"`
 	Resources *Resources `json:"resources,omitempty"`

--- a/server/internal/game/city_test.go
+++ b/server/internal/game/city_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 type mockDatabase struct {
-	GetCityFunc    func(id string) (*City, error)
-	GetCitiesFunc  func(q1, r1, q2, r2 int) ([]*City, error)
-	CreateCityFunc func(c *City) error
-	GetMapFunc     func(minQ, maxQ, minR, maxR int) ([]*MapTile, error)
+	GetCityFunc         func(id string) (*City, error)
+	GetCitiesFunc       func(q1, r1, q2, r2 int) ([]*City, error)
+	CreateCityFunc      func(c *City) error
+	GetMapFunc          func(minQ, maxQ, minR, maxR int) ([]*MapTile, error)
+	GetNextCitySpotFunc func() (*MapTile, error)
 }
 
 func (db *mockDatabase) GetCity(_ context.Context, id string) (*City, error) {
@@ -35,12 +36,16 @@ func (db *mockDatabase) GetMap(_ context.Context, minQ, maxQ, minR, maxR int) ([
 	return db.GetMapFunc(minQ, maxQ, minR, maxR)
 }
 
+func (db *mockDatabase) GetNextCitySpot(_ context.Context) (*MapTile, error) {
+	return db.GetNextCitySpotFunc()
+}
+
 func makeCity(opts ...func(*City)) *City {
 	city := &City{
 		Name:     "Test City",
 		Q:        5,
 		R:        5,
-		Biome:    "plains",
+		Biome:    0,
 		Points:   0,
 		PlayerID: "test-user",
 	}

--- a/server/internal/game/database.go
+++ b/server/internal/game/database.go
@@ -20,6 +20,7 @@ type GameDatabase interface {
 	GetCities(ctx context.Context, q1, r1, q2, r2 int) ([]*City, error)
 	CreateCity(ctx context.Context, c *City) error
 	GetMap(ctx context.Context, minQ, maxQ, minR, maxR int) ([]*MapTile, error)
+	GetNextCitySpot(ctx context.Context) (*MapTile, error)
 }
 
 type PostgresDatabase struct {
@@ -191,7 +192,7 @@ func (db *PostgresDatabase) CreateCity(ctx context.Context, c *City) error {
 	return nil
 }
 
-const getMapQuery = "SELECT q, r, biome FROM world WHERE q BETWEEN $1 AND $2 AND r BETWEEN $3 AND $4"
+const getMapQuery = `SELECT q, r, biome FROM world WHERE q BETWEEN $1 AND $2 AND r BETWEEN $3 AND $4`
 
 func (db *PostgresDatabase) GetMap(ctx context.Context, minQ, maxQ, minR, maxR int) ([]*MapTile, error) {
 	rows, err := db.DB.Query(ctx, getMapQuery, minQ, maxQ, minR, maxR)
@@ -211,4 +212,31 @@ func (db *PostgresDatabase) GetMap(ctx context.Context, minQ, maxQ, minR, maxR i
 	}
 
 	return tiles, nil
+}
+
+const getNextCitySpotQuery = `
+SELECT w.q, w.r, w.biome 
+FROM world w
+LEFT JOIN city c ON w.q = c.q AND w.r = c.r
+WHERE w.settleable=true
+AND c.id IS NULL
+ORDER BY w.q+w.r
+LIMIT 1`
+
+// GetNextCitySpot returns the next available spot for a new city.
+//
+// The spot is determined by the lowest sum of q and r coordinates, which creates a diagonal pattern
+// of city placement starting from the origin (0, 0) and moving outward. Only settleable tiles that
+// are not already occupied by a city are considered.
+func (db *PostgresDatabase) GetNextCitySpot(ctx context.Context) (*MapTile, error) {
+	row := db.DB.QueryRow(ctx, getNextCitySpotQuery)
+	var t MapTile
+	err := row.Scan(&t.Q, &t.R, &t.Biome)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, utils.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
 }

--- a/server/internal/game/game.go
+++ b/server/internal/game/game.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/luisferreira32/stickian/server/internal/utils"
 )
@@ -27,6 +28,8 @@ var (
 
 type GameService struct {
 	Database GameDatabase
+
+	settleLock sync.Mutex
 }
 
 type JoinWorldRequest struct {
@@ -83,15 +86,30 @@ func (g *GameService) JoinWorld(w http.ResponseWriter, r *http.Request) {
 		ID:        userID,
 		PlayerID:  userID,
 		Name:      req.CityName,
-		Q:         0,          // TODO: figure out once we know which spots of the map are buildable where the first city will land
-		R:         0,          // TODO: figure out once we know which spots of the map are buildable where the first city will land
-		Biome:     "mountain", // TODO: figure out once we know which spots of the map are buildable where the first city will land
 		Points:    0,
 		Buildings: &Buildings{},
 		Resources: InitialResources,
 	}
 
-	err := g.Database.CreateCity(r.Context(), newCity)
+	// HACK: to avoid collisions we can have a shared lock on our monolith server!
+	var (
+		citySpot *MapTile
+		err      error
+	)
+	func() {
+		g.settleLock.Lock()
+		defer g.settleLock.Unlock()
+		citySpot, err = g.Database.GetNextCitySpot(r.Context())
+	}()
+	if err != nil {
+		utils.WithError(w, fmt.Errorf("failed to get next city spot: %w", err))
+		return
+	}
+	newCity.Q = citySpot.Q
+	newCity.R = citySpot.R
+	newCity.Biome = citySpot.Biome
+
+	err = g.Database.CreateCity(r.Context(), newCity)
 	if err != nil {
 		utils.WithError(w, err)
 		return


### PR DESCRIPTION
This pull request closes #49 .

Now that we know which spots are possible to settle, we return cities from top left to bottom right order.

Some tasks still missing, but openned the pull request such that we could discuss the decision above.

- [ ] ~extend hotpath testing such that we can generate a map on the fly, load it into the db and run the hotpath testing~ (not in this PR)
- [ ] ~make hotpath testing part of the verification in the ci~ (not in this PR)