### PR TITLE
bugfix: Fix web docker build

### DIFF
--- a/dev.web.Dockerfile
+++ b/dev.web.Dockerfile
@@ -3,8 +3,8 @@ RUN corepack enable
 WORKDIR /app
 
 # install dependencies
-COPY package.json pnpm-lock.yaml .
-RUN pnpm install
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .
+RUN pnpm install --frozen-lockfile 
 
 # copy all sources
 COPY web/ web/

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "vite": "^7.3.3"
   },
   "packageManager": "pnpm@11.1.3",
-  "allowBuilds": [
-    "esbuild"
-  ],
+  "allowBuilds": {
+    "esbuild": true
+  },
   "prettier": {
     "semi": false,
     "singleQuote": true,


### PR DESCRIPTION
With the update of the pnpm now you need to approve builds (after the 0-day CVE due to a malicious post install script). We can add a specific list of deps to approve with the pnpm-workspace.yaml, we just need to make sure it is within the docker build context.